### PR TITLE
Make clj-dde more idiomatic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /checkouts
 pom.xml
 pom.xml.asc
+*.swp
 *.jar
 *.class
 /.lein-*

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Your `project.clj` should include something like the following:
 (defproject foo "0.1.0"
   ...
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [clj-dde "0.1.2"]]
+                 [clj-dde "0.2.0"]]
   ...)
 ```
 
@@ -29,9 +29,21 @@ Work in Progress.
 When you need to connect with a DDE data source...
 
 
-`(dde/convesation)` to setup a connection.
-`(dde/connect "excel" "sheet1")` to connect to a datasource (excel)
-`(dde/request excel-conv "R1C1")` to 'poll' the data contained in cell R1C1
+```clojure
+(def excel-conv (dde/convesation))          ;; to setup a connection.
+(dde/connect excel-conv "excel" "sheet1")   ;; to connect to a datasource (excel)
+(dde/request excel-conv "R1C1")             ;; to 'poll' the data contained in cell R1C1
+```
+
+The major difference between version 0.1.x and 0.2.x is that all functions
+that previously returned `nil` now returns the conversation object, thus
+making the functions chain-able:
+
+```clojure
+(-> (dde/conversation)
+    (dde/connect "excel" "sheet1")
+    (dde/request "R1C1"))
+```
 
 check out the dde-example folder for further examples and usage.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-dde "0.2.0-dev"
+(defproject clj-dde "0.2.0"
   :description "clj-dde: for when you need to connect to a DDE (dynamic data exchange) source"
   :url "http://github.com/tuddman/clj-dde"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,7 @@
-(defproject clj-dde "0.1.2"
+(defproject clj-dde "0.2.0-dev"
   :description "clj-dde: for when you need to connect to a DDE (dynamic data exchange) source"
   :url "http://github.com/tuddman/clj-dde"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]]
   :java-source-paths ["src/java"])
-
-
-
-
-
-

--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,5 @@
   :url "http://github.com/tuddman/clj-dde"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]]
-  :java-source-paths ["src/java"])
+  :java-source-paths ["src/java"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :java-source-paths ["src/java"]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]]}})
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]]
+                   :jvm-opts ["-Djava.library.path=resources"]}})

--- a/src/clj_dde/core.clj
+++ b/src/clj_dde/core.clj
@@ -9,33 +9,33 @@
 
 (defn set-event-listener
   [conv]
-  (.setEventListener conv
-                     (reify DDEClientEventListener
-                       (onItemChanged [this topic item data]
-                         (prn (str "Item Changed: " topic  " , " item  " , " data )))
-                       (onDisconnect [this]
-                         (prn (str "onDisconnect() called."))))))
-
+  (doto conv
+    (.setEventListener
+      (reify DDEClientEventListener
+        (onItemChanged [this topic item data]
+          (prn (str "Item Changed: " topic  " , " item  " , " data )))
+        (onDisconnect [this]
+          (prn (str "onDisconnect() called.")))))))
 
 (defn listen
   [conv]
-  (.setEventListener conv
-                     (reify DDEClientEventListener
-                       (onItemChanged [this _ _ data]
-                         (data))
-                       (onDisconnect [this]
-                         (prn (str "onDisconnect() called."))))))
-
+  (doto conv
+    (.setEventListener
+      (reify DDEClientEventListener
+        (onItemChanged [this _ _ data]
+          (data))
+        (onDisconnect [this]
+          (prn (str "onDisconnect() called.")))))))
 
 (defn listen-and-print-data
   [conv]
-  (.setEventListener conv
-                     (reify DDEClientEventListener
-                       (onItemChanged [this _ _ data]
-                         (prn (str data)))
-                       (onDisconnect [this]
-                         (prn (str "onDisconnect() called."))))))
-
+  (doto conv
+    (.setEventListener
+      (reify DDEClientEventListener
+        (onItemChanged [this _ _ data]
+          (prn (str data)))
+        (onDisconnect [this]
+          (prn (str "onDisconnect() called.")))))))
 
 ;; instantiate a DDEClientConversation
 
@@ -49,7 +49,7 @@
 
 (defn set-timeout
   [conv ms]
-  (.setTimeout conv ms))
+  (doto conv (.setTimeout ms)))
 
 (defn get-timeout
   "returns timeout length in ms"
@@ -58,23 +58,23 @@
 
 (defn connect
   [conv app topic]
-  (.connect conv app topic))
+  (doto conv (.connect app topic)))
 
 (defn disconnect
   [conv]
-  (.disconnect conv))
+  (doto conv .disconnect))
 
 (defn start-advice
   [conv item]
-  (.startAdvice conv item))
+  (doto conv (.startAdvice item)))
 
 (defn stop-advice
   [conv item]
-  (.stopAdvice conv item))
+  (doto conv (.stopAdvice item)))
 
 (defn poke
   [conv topic input]
-  (.poke conv topic input))
+  (doto conv (.poke topic input)))
 
 (defn request
   [conv item]
@@ -82,7 +82,7 @@
 
 (defn execute
   [conv command]
-  (.execute conv command))
+  (doto conv (.execute command)))
 
 (defn get-service
   [conv]

--- a/src/clj_dde/core.clj
+++ b/src/clj_dde/core.clj
@@ -96,5 +96,3 @@
 (defn getTopic
   [conv]
   (.getTopic conv))
-
-

--- a/src/clj_dde/core.clj
+++ b/src/clj_dde/core.clj
@@ -5,13 +5,9 @@
                                  DDEException
                                  DDEMLException]))
 
-#_(System/getProperty "java.library.path")
-
-
-
 ;; implement the DDEClientEventListener interface
 
-(defn setEventListener
+(defn set-event-listener
   [conv]
 (.setEventListener conv
   (reify DDEClientEventListener
@@ -51,11 +47,11 @@
 ;; Method Definitions for a DDEClientConversation.  These are the 'direct' translations of java->clojure.
 ;; TODO: define more 'idiomatic, syntactic sugar' usage methods.
 
-(defn setTimeout
+(defn set-timeout
   [conv ms]
   (.setTimeout conv ms))
 
-(defn getTimeout
+(defn get-timeout
   "returns timeout length in ms"
   [conv]
   (.getTimeout conv))
@@ -68,11 +64,11 @@
   [conv]
   (.disconnect conv))
 
-(defn startAdvice
+(defn start-advice
   [conv item]
   (.startAdvice conv item))
 
-(defn stopAdvice
+(defn stop-advice
   [conv item]
   (.stopAdvice conv item))
 
@@ -88,10 +84,10 @@
   [conv command]
   (.execute conv command))
 
-(defn getService
+(defn get-service
   [conv]
   (.getService conv))
 
-(defn getTopic
+(defn get-topic
   [conv]
   (.getTopic conv))

--- a/src/clj_dde/core.clj
+++ b/src/clj_dde/core.clj
@@ -8,34 +8,25 @@
 ;; implement the DDEClientEventListener interface
 
 (defn set-event-listener
-  [conv]
+  [conv & {:keys [on-disconnect on-item-changed]
+           :or {on-disconnect (fn [_])
+                on-item-changed (fn [_ _ _ _])}}]
   (doto conv
     (.setEventListener
       (reify DDEClientEventListener
-        (onItemChanged [this topic item data]
-          (prn (str "Item Changed: " topic  " , " item  " , " data )))
-        (onDisconnect [this]
-          (prn (str "onDisconnect() called.")))))))
+        (onItemChanged [this topic item data] (on-item-changed this topic item data))
+        (onDisconnect  [this] (on-disconnect this))))))
 
 (defn listen
   [conv]
-  (doto conv
-    (.setEventListener
-      (reify DDEClientEventListener
-        (onItemChanged [this _ _ data]
-          (data))
-        (onDisconnect [this]
-          (prn (str "onDisconnect() called.")))))))
+  (set-event-listener conv
+                      :on-disconnect (fn [_] (prn (str "onDisconnect() called.")))))
 
 (defn listen-and-print-data
   [conv]
-  (doto conv
-    (.setEventListener
-      (reify DDEClientEventListener
-        (onItemChanged [this _ _ data]
-          (prn (str data)))
-        (onDisconnect [this]
-          (prn (str "onDisconnect() called.")))))))
+  (set-event-listener conv
+                      :on-item-changed (fn [_ _ _ data] (prn (str data)))
+                      :on-disconnect   (fn [_] (prn (str "onDisconnect() called.")))))
 
 ;; instantiate a DDEClientConversation
 

--- a/src/clj_dde/core.clj
+++ b/src/clj_dde/core.clj
@@ -9,32 +9,32 @@
 
 (defn set-event-listener
   [conv]
-(.setEventListener conv
-  (reify DDEClientEventListener
-  (onItemChanged [this topic item data]
-               (prn (str "Item Changed: " topic  " , " item  " , " data )))
-  (onDisconnect [this]
-                (prn (str "onDisconnect() called."))))))
+  (.setEventListener conv
+                     (reify DDEClientEventListener
+                       (onItemChanged [this topic item data]
+                         (prn (str "Item Changed: " topic  " , " item  " , " data )))
+                       (onDisconnect [this]
+                         (prn (str "onDisconnect() called."))))))
 
 
 (defn listen
   [conv]
-(.setEventListener conv
-  (reify DDEClientEventListener
-  (onItemChanged [this _ _ data]
-               (data))
-  (onDisconnect [this]
-                (prn (str "onDisconnect() called."))))))
+  (.setEventListener conv
+                     (reify DDEClientEventListener
+                       (onItemChanged [this _ _ data]
+                         (data))
+                       (onDisconnect [this]
+                         (prn (str "onDisconnect() called."))))))
 
 
 (defn listen-and-print-data
   [conv]
-(.setEventListener conv
-  (reify DDEClientEventListener
-  (onItemChanged [this _ _ data]
-               (prn (str data)))
-  (onDisconnect [this]
-                (prn (str "onDisconnect() called."))))))
+  (.setEventListener conv
+                     (reify DDEClientEventListener
+                       (onItemChanged [this _ _ data]
+                         (prn (str data)))
+                       (onDisconnect [this]
+                         (prn (str "onDisconnect() called."))))))
 
 
 ;; instantiate a DDEClientConversation

--- a/src/clj_dde/core.clj
+++ b/src/clj_dde/core.clj
@@ -1,10 +1,9 @@
 (ns clj-dde.core
-  [:import
-        [com.pretty_tools.dde.client DDEClientConversation]
-        [com.pretty_tools.dde.client DDEClientEventListener]
-        [com.pretty_tools.dde ClipboardFormat]
-        [com.pretty_tools.dde DDEException]
-        [com.pretty_tools.dde DDEMLException]])
+  (:import [com.pretty_tools.dde.client DDEClientConversation
+                                        DDEClientEventListener]
+           [com.pretty_tools.dde ClipboardFormat
+                                 DDEException
+                                 DDEMLException]))
 
 #_(System/getProperty "java.library.path")
 


### PR DESCRIPTION
The main purpose of this pull-request is to:
1. Make the function names more idiomatic by replacing camelCase with hyphenation
2. Make the functions which originally return nil to return the conversation object
3. Refactor set-event-listener to accept the handler functions

Hopefully, these pave the way for moving this project forward.
